### PR TITLE
Implements a chromosome ID normalization step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV HTSLIB_DOWNLOAD_URL https://github.com/samtools/htslib/releases/download/1.3
 
 RUN buildDeps='gcc libc6-dev make zlib1g-dev' \
     && set -x \
-    && apt-get update && apt-get install -y $buildDeps bzip2 genometools vcftools --no-install-recommends \
+    && apt-get update && apt-get install -y $buildDeps bzip2 genometools vcftools perl-base --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && wget "$HTSLIB_DOWNLOAD_URL" \
     && mkdir -p /usr/src/htslib \
@@ -39,6 +39,7 @@ ADD cyverse-cli.tgz /usr/local
 RUN /usr/local/cyverse-cli/bin/tenants-init -b -t iplantc.org
 
 COPY bin/process_genomic_data_format_files.sh /usr/local/bin
+COPY bin/normalize_athaliana_chrom_ids.pl /usr/local/bin
 
 RUN mkdir /data
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,8 @@ templatize:
 	sed -e 's|{{tool_version}}|$(tool_version)|g' \
 		-e 's|{{IMAGENAME}}|$(TOOL)|g' \
 		$(SRC)/deploy_community_tracks.sh > $(BIN)/deploy_community_tracks.sh
-	find $(BIN) -type f -name '*.sh' -exec chmod a+rx {} \;
+	cp $(SRC)/normalize_athaliana_chrom_ids.pl $(BIN)/.
+	find $(BIN) -type f \( -name '*.sh' -o -name '*.pl' \) -exec chmod a+rx {} \;
 
 .PHONY: clean
 clean:

--- a/src/normalize_athaliana_chrom_ids.pl
+++ b/src/normalize_athaliana_chrom_ids.pl
@@ -1,0 +1,48 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+my @default_chrom_ids = ();
+my %CHROM_ID_VAR_MAP = ();
+
+## read <DATA> containing all chromosome Id variations
+## possible chromosome Ids are converted to lowercase strings
+## store mapping between possible and expected chromosome Ids
+## e.g. "chr01" resolves to "Chr1" (expected)
+while(<DATA>) {
+    chomp;
+    my @line = split " ";
+    push @default_chrom_ids, $line[0];
+    for(my $i = 0; $i < scalar @line; $i++) {
+        $CHROM_ID_VAR_MAP{lc $line[$i]} = $line[0];
+    }
+}
+close DATA;
+
+## iterate through input file (passed by name or via stdin)
+## if line starts with '#', print as-is
+## else, split line at '\t', verify and fix chrom ID in first column
+while(<>) {
+    chomp;
+    if(/^#/) { print "$_\n"; }
+    else {
+        my @line = split /\t/;
+        my $k = lc $line[0];
+        if(defined $CHROM_ID_VAR_MAP{$k}) {
+            $line[0] = $CHROM_ID_VAR_MAP{$k};
+        }
+        print join ("\t", @line) . "\n";
+    }
+}
+
+exit;
+
+__DATA__
+Chr1 Chr01 1 CP002684.1 NC_003070.9 AtChr1
+Chr2 Chr02 2 CP002685.1 NC_003071.7 AtChr2
+Chr3 Chr03 3 CP002686.1 NC_003074.8 AtChr3
+Chr4 Chr04 4 CP002687.1 NC_003075.7 AtChr4
+Chr5 Chr05 5 CP002688.1 NC_003076.8 AtChr5
+ChrC ChrCp C AP000423.1 NC_000932.1 Cp Pt
+ChrM ChrMt M Y08501.2 NC_001284.2 Mt


### PR DESCRIPTION
Hi @eriksf ,

Thanks for developing this pipeline, looks really good! Wanted to contribute the following code changes, which implements a CHROM ID normalization step during the processing of BED/VCF/GFF files, based on all different possible ways used by the community to represent _A. thaliana_ chromosome identifiers. 

Please note, I added a new package to the `Dockerfile` build process, `perl-base`, to support running processing scripts written in Perl. The newly added package does not have any dependencies itself, so it shouldn't add too much to the overhead.

Please review this commit and let me know if you agree with these changes!

Thank you.
Vivek

P.S. Please feel free to delete this feature branch once you decide to merge the code. Thanks!
## 

ORIGINAL COMMIT MSG
- Adds intermediary perl script to cleanup/normalize CHROM Identifiers
- Updates Makefile to reflect this change
- Adds `perl-base` Ubuntu package to Dockerfile
