### PR TITLE
Paths point to araport/community-tracks/staging instead of shared

### DIFF
--- a/conf/config.sh
+++ b/conf/config.sh
@@ -7,5 +7,5 @@ DATESTAMP=$(date +%m%d%Y-%k%M)
 BEARER_TOKEN=19aaedef4af51ca537e9a795364d86c
 APP_NAME=eriksf-araport-deploy-community-tracks
 APP_ID=eriksf-araport-deploy-community-tracks-${VERSION}
-ARCHIVE_PATH=araport/community-tracks/shared
+ARCHIVE_PATH=araport/community-tracks/staging
 DEPLOYMENT_PATH=eriksf/applications/deploy-community-tracks

--- a/job.json
+++ b/job.json
@@ -1,6 +1,6 @@
 {
   "name":"example",
-  "appId": "vaughn-araport-deploy-community-tracks-0.0.1",
+  "appId": "vaughn-araport-deploy-community-tracks-0.0.2",
   "batchQueue": "debug",
   "executionSystem": "docker.iplantcollaborative.org",
   "maxRunTime": "00:10:00",
@@ -9,7 +9,7 @@
   "processorsPerNode": 1,
   "archive": true,
   "archiveSystem": "data.iplantcollaborative.org",
-  "archivePath": "araport/community-tracks/shared",
+  "archivePath": "araport/community-tracks/staging",
   "inputs": {
     "GDF_FILE": "agave://data.iplantcollaborative.org/araport/community-tracks/samples/pollen.bed"
   },

--- a/template.bashx
+++ b/template.bashx
@@ -26,7 +26,7 @@ AGAVE_BEARER_TOKEN=${AGAVE_BEARER_TOKEN}
 AGAVE_JOB_ID=${AGAVE_JOB_ID}
 AGAVE_JOB_OWNER=${AGAVE_JOB_OWNER}
 AGAVE_SYSTEM_ID=data.iplantcollaborative.org
-AGAVE_SHARED_DIR=araport/community-tracks/shared
+AGAVE_SHARED_DIR=araport/community-tracks/staging
 AGAVE_TRACK_URL_BASE=https://de.iplantcollaborative.org/anon-files/iplant/home
 AGAVE_ANONYMOUS_USER=anonymous
 EOT


### PR DESCRIPTION
Updated the permissions on the storage resource for published tracks. We should be able to use /staging now instead of archiving straight to /shared.  @eriksf  please accept the PR if you agree with the changes! 
